### PR TITLE
Add current linkedin image to user at login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,14 +31,17 @@ class User < ActiveRecord::Base
 
   def self.connect_to_linkedin(auth, signed_in_resource =nil)
     user = User.where(:provider => auth.provider, :uid => auth.uid).first
+    image_url = auth.extra.raw_info.pictureUrls.values[1][0]
     if user
+      user.update_attributes(image_url: image_url)
       return user
     else
       registered_user = User.where(:email => auth.info.email).first
       if registered_user
+        registered_user.update_attributes(image_url: image_url)
         return registered_user
       else
-        user = User.create(first_name:auth.info.first_name, last_name:auth.info.last_name, provider:auth.provider, uid:auth.uid, email:auth.info.email, password:Devise.friendly_token[0,20] )
+        user = User.create(first_name:auth.info.first_name, last_name:auth.info.last_name, provider:auth.provider, uid:auth.uid, email:auth.info.email, image_url:image_url,  password:Devise.friendly_token[0,20] )
         UserMailer.welcome_mail(user).deliver
         return user
       end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -8,6 +8,7 @@
           <li><%= message%></li>
         <%end%>
       <%end%>
+      <%= image_tag @user.image_url %>
       <%= f.label :First_Name %>
       <%= f.text_field :first_name %></br>
       <%= f.label :Last_Name%>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -233,7 +233,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-   config.omniauth :linkedin, ENV['LINKEDIN_ID'], ENV['LINKEDIN_SECRET']
+   config.omniauth :linkedin, ENV['LINKEDIN_ID'], ENV['LINKEDIN_SECRET'], :fields => ['first-name', 'last-name', 'email-address', 'picture-urls::(original)', 'id']
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/db/migrate/20160324172132_add_image_to_users.rb
+++ b/db/migrate/20160324172132_add_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160201222226) do
+ActiveRecord::Schema.define(version: 20160324172132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 20160201222226) do
     t.integer  "mentor_times",                default: 1
     t.integer  "mentor_limit",                default: 1
     t.boolean  "is_participating_this_month"
+    t.string   "image_url"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
Adds new fields to request from Linkedin. A url to the Linkedin profile picture is returned. The pic is saved to the user at every log in. 

Adds :image_url to the Users schema. 
