### PR TITLE
Implement the Developer Oauth Strategy so we can log in in dev without Linked in

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,4 +1,4 @@
-class OmniauthCallbacksController < Devise::OmniauthCallbacksController   
+class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def linkedin
     auth = env["omniauth.auth"]
     @user = User.connect_to_linkedin(request.env["omniauth.auth"],current_user)
@@ -10,4 +10,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to root_path
     end
   end
+
+  skip_before_action :verify_authenticity_token, only: :developer
+  alias_method :developer, :linkedin
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def default_omniauth_authorize_path
+    user_omniauth_authorize_path(ENV['DEFAULT_OMNIAUTH_PROVIDER'] || :linkedin)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,6 @@
 #  top_3_interests             :text             default([]), is an Array
 #  live_in_detroit             :boolean          default(TRUE)
 #  waitlist                    :boolean          default(TRUE)
-#  is_participating_next_month :boolean          default(FALSE)
 #  is_assigned_peer_group      :boolean          default(FALSE)
 #  mentor_times                :integer          default(1)
 #  mentor_limit                :integer          default(1)
@@ -72,28 +71,29 @@ class User < ActiveRecord::Base
     "C-Level/Founder"
   ]
 
-  def self.connect_to_linkedin(auth, signed_in_resource =nil)
+  def self.connect_to_linkedin(auth, signed_in_resource=nil)
     user = User.where(:provider => auth.provider, :uid => auth.uid).first
+    user ||= User.where(email: auth.info.email).first
     image_url = auth.extra.raw_info.pictureUrls.values[1][0]
     if user
       user.update_attributes(image_url: image_url)
-      return user
     else
-      registered_user = User.where(:email => auth.info.email).first
-      if registered_user
-        registered_user.update_attributes(image_url: image_url)
-        return registered_user
-      else
-        user = User.create(first_name:auth.info.first_name, last_name:auth.info.last_name, provider:auth.provider, uid:auth.uid, email:auth.info.email, image_url:image_url,  password:Devise.friendly_token[0,20] )
+      user = User.create(
+        auth.info.slice(:first_name, :last_name, :email).merge(
+          auth.slice(:provider, :uid)
+        ).merge(
+          image_url: image_url,
+          password: Devise.friendly_token[0,20]
+        ).to_h
+      )
 
-        action = :new_user
-        message  = "#{user.id} is a new user"
-        SlackNotification.notify(action, message)
+      action = :new_user
+      message  = "#{user.id} is a new user"
+      SlackNotification.notify(action, message)
 
-        UserMailer.welcome_mail(user).deliver
-        return user
-      end
+      UserMailer.welcome_mail(user).deliver
     end
+    return user
   end
 
   def self.update_month

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,13 +10,13 @@
     <li>
       <% if current_user and user_signed_in? %>
 
-        <a href=<%=user_path(@user)%> class="avatar">
-          <%= image_tag @user.get_image_url, class:"img-circle img-responsive" %>
+        <a href="<%= user_path(@user) %>" class="avatar">
+          <%= image_tag @user.get_image_url, class: "img-circle img-responsive" %>
           <%= @user.full_name %>
         </a>
-        <%= link_to "Sign out", destroy_user_session_path, :method => :delete %>
+        <%= link_to "Sign out", destroy_user_session_path, method: :delete %>
       <% else %>
-        <%= link_to "Sign in", user_omniauth_authorize_path('linkedin'), class:"with-border" %>
+        <%= link_to "Sign in", default_omniauth_authorize_path, class: "with-border" %>
       <% end %>
     </li>
   </ul>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -5,7 +5,7 @@
       Studies show that mentors and friends determine your career path. Find that support group here:
     </p>
     <div id="joinNowCTA">
-      <%= link_to "Join Now", user_omniauth_authorize_path('linkedin') %>
+      <%= link_to "Join Now", default_omniauth_authorize_path %>
     </div>
   </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -233,7 +233,11 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-   config.omniauth :linkedin, ENV['LINKEDIN_ID'], ENV['LINKEDIN_SECRET'], :fields => ['first-name', 'last-name', 'email-address', 'picture-urls::(original)', 'id']
+  config.omniauth :developer unless Rails.env.production?
+
+  if ENV['LINKEDIN_ID'] and ENV['LINKEDIN_SECRET']
+    config.omniauth :linkedin, ENV['LINKEDIN_ID'], ENV['LINKEDIN_SECRET'], fields: ['first-name', 'last-name', 'email-address', 'picture-urls::(original)', 'id']
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,21 @@
+module OmniAuth
+  module Strategies
+    class Developer
+      # emulate fields used from LinkedIn
+      option :fields, [:first_name, :last_name, :email]
+
+      extra do
+        {
+          'raw_info' => {
+            'pictureUrls' => {'0' => nil, '1' => [random_pic]}
+          }
+        }
+      end
+
+      def random_pic
+        n = request.params['email'].length % 10 + 1 rescue 0
+        "http://lorempixel.com/400/400/cats/#{n}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Migrations
NO

## Description
This improves devloper ergonomics by making the LinkedIn Oauth optional in development

## Deploy Notes
None

## Impacted Areas in Application

* Logging in... though there should be no change in production

## Background

The omniauth gem comes with a Developer oauth endpoint (conveniently).  When logging in with an email address in the system you do not need to fill in the first/last name fields, just the emails

## Screenshots

N/A

## Definition of Done

- [ ] This PR has appropriate test coverage.
- [ ] Documentation has been updated. *(if needed)*
