### PR TITLE
Feature/other locations

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -59,6 +59,7 @@ class UsersController < ApplicationController
       :current_goal,
       :live_in_detroit,
       :location_id,
+      :zip_code,
       top_3_interests: []
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,8 @@ class User < ActiveRecord::Base
   validates_presence_of :mentor_industry, if: :mentor
   after_validation :check_industry
 
+  before_save :ensure_location_or_zip
+
   CURRENT_GOALS = [
     "Rising the ranks / breaking the glass ceiling",
     "Switching industries",
@@ -147,5 +149,11 @@ class User < ActiveRecord::Base
 
   def full_name
     "#{self.first_name} #{self.last_name}"
+  end
+
+  private
+
+  def ensure_location_or_zip
+    self.zip_code = nil if location_id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@
 #  is_participating_this_month :boolean
 #  image_url                   :string(255)
 #  location_id                 :integer
-#  zip_code                    :integer
+#  zip_code                    :string(10)
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@
 #  is_participating_this_month :boolean
 #  image_url                   :string(255)
 #  location_id                 :integer
+#  zip_code                    :integer
 #
 # Indexes
 #

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -41,24 +41,23 @@
             </h4>
             <h4 class="medium-frame">Email:
               <div class="form-group">
-                <%= f.text_field :email, class: 'form-control' %></br>
+                <%= f.text_field :email, class: 'form-control' %>
               </div>
             </h4>
-            <h4 class="medium-frame">I Live In Detroit:
+            <h4 class="medium-frame">Location:
               <div class="form-group">
-                <%= f.select :live_in_detroit, options_for_select([["Yes",true],["No",false]], @user.live_in_detroit) %></br>
-                <div id="live_in_detroit_info">
-                  <p>What if I don't live in Detroit?<p>
-                  <p>
-                    You will not be placed in a peer group and can only mentor.
-                    However, we're working hard to expand Women Rising to other areas. Stay tuned!
-                  </p>
-                </div>
+                <%= f.collection_select(:location_id, Location.all, :id, :city_state, include_blank: 'Other') %>
               </div>
-              <h4 class="medium-frame">Location:
-                <div class="form-group">
-                  <%= f.collection_select(:location_id, Location.all, :id, :city_state) %></br>
-                </div>
+            </h4>
+            <h4 class="medium-frame hidden" id="zip-code">Zip Code:
+              <div class="form-group">
+                <%= f.number_field :zip_code, class: 'form-control' %>
+                <p>
+                  You will not be placed in a peer group and can only mentor.
+                  However, we're working hard to expand Women Rising to other areas.
+                  Enter your zip code to let us know where you want a Women Rising chapter.
+                </p>
+              </div>
             </h4>
             <h4 class="medium-frame">Primary Industry:
               <div class="form-group">
@@ -131,3 +130,18 @@
     </div>
   </main>
 <%end%>
+
+<script>
+  $(document).ready(function() {
+    if ($('#user_location_id').val() == "") {
+      $('#zip-code').removeClass("hidden");
+    };
+    $('#user_location_id').change(function() {
+      if ($('#user_location_id').val() == "") {
+        $('#zip-code').removeClass("hidden");
+      } else {
+        $('#zip-code').addClass("hidden");
+      };
+    });
+  });
+</script>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -132,16 +132,9 @@
 <%end%>
 
 <script>
-  $(document).ready(function() {
-    if ($('#user_location_id').val() == "") {
-      $('#zip-code').removeClass("hidden");
-    };
-    $('#user_location_id').change(function() {
-      if ($('#user_location_id').val() == "") {
-        $('#zip-code').removeClass("hidden");
-      } else {
-        $('#zip-code').addClass("hidden");
-      };
-    });
+  $(function() {
+    $('#user_location_id').on('change', function() {
+      $('#zip-code').toggleClass("hidden", $(this).val() !== "");
+    }).trigger('change');
   });
 </script>

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,7 +14,7 @@ development:
 
 test:
   <<: *default
-  database: womenrising_development
+  database: womenrising_test
   <% if ENV['WOMENRISING_DOCKER'] %>
   username: postgres
   password:

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ test:
   <% if ENV['WOMENRISING_DOCKER'] %>
   username: postgres
   password:
-  host: postgres
+  host: localhost
   <% end %>
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ test:
   <% if ENV['WOMENRISING_DOCKER'] %>
   username: postgres
   password:
-  host: localhost
+  host: postgres
   <% end %>
 
 

--- a/db/migrate/20170218190259_add_zip_code_to_user.rb
+++ b/db/migrate/20170218190259_add_zip_code_to_user.rb
@@ -1,0 +1,5 @@
+class AddZipCodeToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :zip_code, :integer
+  end
+end

--- a/db/migrate/20170304172428_change_zip_code_for_user.rb
+++ b/db/migrate/20170304172428_change_zip_code_for_user.rb
@@ -1,0 +1,9 @@
+class ChangeZipCodeForUser < ActiveRecord::Migration
+  def up
+    change_column :users, :zip_code, :string, limit: 10
+  end
+
+  def down
+    change_column :users, :zip_code, 'integer USING CAST(zip_code AS integer)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170120230005) do
+ActiveRecord::Schema.define(version: 20170218190259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20170120230005) do
     t.boolean  "is_participating_this_month"
     t.string   "image_url"
     t.integer  "location_id"
+    t.integer  "zip_code"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170218190259) do
+ActiveRecord::Schema.define(version: 20170304172428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,12 +82,12 @@ ActiveRecord::Schema.define(version: 20170218190259) do
   end
 
   create_table "users", force: true do |t|
-    t.string   "email",                       default: "",    null: false
-    t.string   "encrypted_password",          default: "",    null: false
+    t.string   "email",                                  default: "",    null: false
+    t.string   "encrypted_password",                     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",               default: 0,     null: false
+    t.integer  "sign_in_count",                          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
@@ -98,22 +98,22 @@ ActiveRecord::Schema.define(version: 20170218190259) do
     t.string   "uid"
     t.string   "first_name"
     t.string   "last_name"
-    t.boolean  "mentor",                      default: false
+    t.boolean  "mentor",                                 default: false
     t.string   "primary_industry"
     t.integer  "stage_of_career"
     t.string   "mentor_industry"
     t.string   "peer_industry"
     t.string   "current_goal"
-    t.text     "top_3_interests",             default: [],                 array: true
-    t.boolean  "live_in_detroit",             default: true
-    t.boolean  "waitlist",                    default: true
-    t.boolean  "is_assigned_peer_group",      default: false
-    t.integer  "mentor_times",                default: 1
-    t.integer  "mentor_limit",                default: 1
+    t.text     "top_3_interests",                        default: [],                 array: true
+    t.boolean  "live_in_detroit",                        default: true
+    t.boolean  "waitlist",                               default: true
+    t.boolean  "is_assigned_peer_group",                 default: false
+    t.integer  "mentor_times",                           default: 1
+    t.integer  "mentor_limit",                           default: 1
     t.boolean  "is_participating_this_month"
     t.string   "image_url"
     t.integer  "location_id"
-    t.integer  "zip_code"
+    t.string   "zip_code",                    limit: 10
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/features/user_information_spec.rb
+++ b/spec/features/user_information_spec.rb
@@ -27,7 +27,7 @@ feature 'User can edit information' do
     fill_in :user_zip_code, with: '12345'
     click_on 'Submit'
     expect(user.reload.location).to be_nil
-    expect(user.zip_code).to eq 12345
+    expect(user.zip_code).to eq '12345'
   end
 
   scenario 'clears zip code if they choose an existing location' do

--- a/spec/features/user_information_spec.rb
+++ b/spec/features/user_information_spec.rb
@@ -17,7 +17,7 @@ feature 'User can edit information' do
     expect(page).to have_content 'Location'
     select 'Boulder, CO'
     click_on 'Submit'
-    expect(user.reload.location).to_not be_nil
+    expect(user.reload.location).to eq boulder
     expect(page).to have_content user.location.city_state
   end
 
@@ -28,5 +28,18 @@ feature 'User can edit information' do
     click_on 'Submit'
     expect(user.reload.location).to be_nil
     expect(user.zip_code).to eq 12345
+  end
+
+  scenario 'clears zip code if they choose an existing location' do
+    click_on 'Edit My Profile'
+    select 'Other'
+    fill_in :user_zip_code, with: '12345'
+    click_on 'Submit'
+
+    click_on 'Edit My Profile'
+    select 'Detroit, MI'
+    click_on 'Submit'
+    expect(user.reload.location).to eq detroit
+    expect(user.zip_code).to be_nil
   end
 end

--- a/spec/features/user_information_spec.rb
+++ b/spec/features/user_information_spec.rb
@@ -20,4 +20,13 @@ feature 'User can edit information' do
     expect(user.reload.location).to_not be_nil
     expect(page).to have_content user.location.city_state
   end
+
+  scenario 'can choose other location' do
+    click_on 'Edit My Profile'
+    select 'Other'
+    fill_in :user_zip_code, with: '12345'
+    click_on 'Submit'
+    expect(user.reload.location).to be_nil
+    expect(user.zip_code).to eq 12345
+  end
 end


### PR DESCRIPTION
## Migrations
YES

## Description
Allow users to choose "Other" location, and when they do, they should provide their zipcode.

## Deploy Notes
Requires db migration

## Github Issue
Fixes #31 

## Background

`lives_in_detroit` is no longer there for the user to choose, but has not been removed from the code base. We need to make a decision whether to add it back, and have both for a time on staging. Or just agree not to deploy staging to production until we change the code base logic. (Should be the very next PR either way)

## Screenshots

![image](https://cloud.githubusercontent.com/assets/11759443/23323614/8726033e-faa6-11e6-9a88-9029fae32e43.png)

![image](https://cloud.githubusercontent.com/assets/11759443/23323619/9043535e-faa6-11e6-8aa6-8eb4ac74d530.png)


## Definition of Done

- [X] This PR has appropriate test coverage.

