### PR TITLE
#25 - Rake task for migrating live_in_detroit users

### DIFF
--- a/lib/tasks/live_in_detroit.rake
+++ b/lib/tasks/live_in_detroit.rake
@@ -1,0 +1,6 @@
+desc 'Migrate live_in_detroit users to Detroit location'
+
+task :live_in_detroit => :environment do
+  location = Location.first_or_create(city: 'Detroit', state: 'MI')
+  User.where(live_in_detroit: true).update_all(location_id: location.id)
+end


### PR DESCRIPTION
## Migrations
NO

## Description

Adds a rake task that sets `location_id` to the id for the Detroit location for all users who have `live_in_detroit` set to to `true`.

**NOTE:** The dev db wasn't seeded with a Detroit location, so I used `Location.first_or_create` in case it already exists in production.

## Github Issue
Fixes #25 

## Background

We want to be able to drop the `live_in_detroit` field from the `User` table.
