### PR TITLE
25 Fix rake task to find, not use first

### DIFF
--- a/lib/tasks/live_in_detroit.rake
+++ b/lib/tasks/live_in_detroit.rake
@@ -1,6 +1,6 @@
 desc 'Migrate live_in_detroit users to Detroit location'
 
 task :live_in_detroit => :environment do
-  location = Location.first_or_create(city: 'Detroit', state: 'MI')
+  location = Location.find_or_create_by(city: 'Detroit', state: 'MI')
   User.where(live_in_detroit: true).update_all(location_id: location.id)
 end


### PR DESCRIPTION
## Migrations
NO

## Description
The rake task was using the first location, instead we need to find by the city and state

## Github Issue
Fixes #25 

## Background

Staging has already been updated manually, but this rake task will need to be run in production.

## Definition of Done

- [X] This PR has appropriate test coverage. (manually)
