### PR TITLE
#22 - View other profiles

### DIFF
--- a/app/assets/stylesheets/styles.css.scss
+++ b/app/assets/stylesheets/styles.css.scss
@@ -562,5 +562,5 @@ a.btn:hover {
 	background-color: #fff;
 }
 .list-md-inline li {
-	display: inline-block
+	display: inline-block;
 }

--- a/app/assets/stylesheets/styles.css.scss
+++ b/app/assets/stylesheets/styles.css.scss
@@ -543,3 +543,17 @@ a.btn:hover {
 	color: white;
 	font-weight: bold;
 }
+
+/* Peer List Section */
+.list-style-none {
+	-webkit-padding-start: 0;
+	list-style: none;
+}
+.img-thumbnail-small {
+	width: 150px;
+}
+.well-plain {
+	border: none;
+	box-shadow: none;
+	background-color: #fff;
+}

--- a/app/assets/stylesheets/styles.css.scss
+++ b/app/assets/stylesheets/styles.css.scss
@@ -432,6 +432,10 @@ nav {
 	.arrows {
 		display: block;
 	}
+
+	.list-md-inline li {
+		display: list-item;
+	}
 }
 
 /* Large devices (large desktops, 1200px and up) */
@@ -556,4 +560,7 @@ a.btn:hover {
 	border: none;
 	box-shadow: none;
 	background-color: #fff;
+}
+.list-md-inline li {
+	display: inline-block
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = current_user
+    @user = User.find(params[:id])
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,9 +154,13 @@ class User < ActiveRecord::Base
     "#{self.first_name} #{self.last_name}"
   end
 
+  def peer_group
+    peer_groups.last if peer_groups.any?
+  end
+
   def peers
-    if peer_groups.any?
-      peer_groups.last.users - [self]
+    if peer_group
+      peer_group.users - [self]
     else
       []
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -154,6 +154,14 @@ class User < ActiveRecord::Base
     "#{self.first_name} #{self.last_name}"
   end
 
+  def peers
+    if peer_groups.any?
+      peer_groups.last.users - [self]
+    else
+      []
+    end
+  end
+
   private
 
   def ensure_location_or_zip

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,6 +7,22 @@
   <div class="large-frame">
     <h3><%= @user.first_name%> <%= @user.last_name %></h3>
   </div>
+  <% if @user.peers.any? %>
+    <div class="large-frame">
+      <h2>Your Peers</h2>
+      <br>
+      <ul class="list-style-none">
+        <% @user.peers.each do |peer| %>
+          <li class="text-center well well-plain">
+            <a href="<%= user_path(peer) %>">
+              <%= image_tag(peer.image_url, class: "img-thumbnail img-thumbnail-small") %>
+              <h4 class="text-center"><%= peer.full_name %></h4>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 </aside>
 
 <main class="col-md-8 side-frame">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
     <div class="large-frame">
       <h2>Your Peers</h2>
       <br>
-      <ul class="list-style-none">
+      <ul class="list-style-none list-md-inline">
         <% @user.peers.each do |peer| %>
           <li class="text-center well well-plain">
             <a href="<%= user_path(peer) %>">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,12 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Fabricator(:location) do
+  city { Faker::Address.city }
+  state { Faker::Address.state_abbr }
+end
+
 Fabricator(:user) do
   email { Faker::Internet.email}
   password {"testtingstuff"}
@@ -19,9 +25,11 @@ Fabricator(:user) do
   current_goal {["Rising the ranks / breaking the glass ceiling","Switching industries","Finding work/life balance"].sample}
   top_3_interests {["Arts", "Music", "Crafting", "Home improvement / Decorating", "Being a mom", "Dogs", "Cats", "Watch    ing Sports", "Outdoors / Hiking", "Exercise", "Biking", "Yoga", "Running", "Beer","Wine","Traveling"," Local events",    "Reading", "Photography", "Movies","Cooking / Eating / Being a foodie" ,"Social issues / volunteering","Video Games"].sample(3)}
   is_participating_this_month {%w(true false).sample}
+  location_id { rand(Location.count) }
 end
 
-150.times { Fabricate(:user)}
+10.times { Fabricate(:location) }
+150.times { Fabricate(:user) }
 
 
 AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,6 +21,24 @@ FactoryGirl.define do
     linkedin_url { Faker::Internet.url }
   end
 
+  factory :active_user, class: User do
+    email { generate(:email) }
+    password {"testtingstuff"}
+    password_confirmation {|attrs| attrs[:password]}
+    first_name { Faker::Name.first_name}
+    last_name {Faker::Name.last_name}
+    mentor { true }
+    primary_industry { "Busines" }
+    stage_of_career { 1 }
+    mentor_industry { "Business" }
+    peer_industry {"Business" }
+    current_goal { "Finding work/life balance" }
+    top_3_interests { ["Arts", "Music", "Crafting"] }
+    is_participating_this_month { true }
+    waitlist { false }
+    linkedin_url { Faker::Internet.url }
+  end
+
   factory :skinny_user, class: User do
     email { generate(:email) }
     first_name { Faker::Name.first_name }

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'user show page' do
+  let!(:location) { create :location }
+  let!(:user) { create :active_user, location: location }
+  let!(:other_user) { create :active_user, location: location }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  it 'should be viewable by other users' do
+    visit user_path(other_user)
+    expect(page).to have_content other_user.full_name
+  end
+
+  it 'should show other users in peer group' do
+    PeerGroup.generate_groups
+    visit user_path(user)
+    expect(page).to have_content other_user.full_name
+  end
+end


### PR DESCRIPTION
## Migrations
NO

## Description

* Allows users to view other users profiles
* Adds a section to the user profile showing other users in current peer group
* Adds locations to `seed.rb` so features that rely on locations can be tested in development (e.g generating groups and making sure users can see their peers on their profile).

## Background

This branches off my other "install guard" branch

## Github Issue
Fixes #22 

## Screenshots

![screen shot 2017-04-29 at 5 37 19 pm](https://cloud.githubusercontent.com/assets/964090/25559897/893a3dc8-2d02-11e7-8927-dc7a1538579a.png)

## Definition of Done

- [x] This PR has appropriate test coverage.
