### PR TITLE
switch email smtp to send grid

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,14 +59,20 @@ Rails.application.configure do
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # config.assets.precompile += %w( search.js )
+
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
   config.action_mailer.smtp_settings = {
-    :address => "smtp.gmail.com",
-    :port    => 587,
-    :user_name => ENV['gmail_username'],
-    :password => ENV['gmail_password'],
-    :authentication => "plain",
+    :user_name => ENV['SENDGRID_USERNAME'],
+    :password => ENV['SENDGRID_PASSWORD'],
+    :domain => 'womenrising.co',
+    :address => 'smtp.sendgrid.net',
+    :port => 587,
+    :authentication => :plain,
     :enable_starttls_auto => true
+  }
+  config.action_mailer.default_options = {
+    :reply_to => 'info@womenrising.co'
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Migrations
NO

## Description
This switches transactional emails sent by the application to use sendgrid instead of gmail

## Deploy Notes
Make sure sendgrid is provisioned in heroku

if you add an SPF record in the DNS settings, the emails can come from a @womenrising.co address: https://sendgrid.com/docs/Glossary/spf.html

