### PR TITLE
From instead of reply-to

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,7 @@ Rails.application.configure do
     :enable_starttls_auto => true
   }
   config.action_mailer.default_options = {
-    :reply_to => 'info@womenrising.co'
+    :from => 'info@womenrising.co'
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Migrations
NO

## Description
we made it so the emails come from @womenrising.co if you add an SPF to the DNS settings. https://sendgrid.com/docs/Glossary/spf.html

So now we need from instead of reply-to

## Github Issue
Fixes #72 
