### PR TITLE
Make chained .where clauses more readable in get_possible_mentors method

### DIFF
--- a/app/models/mentorship.rb
+++ b/app/models/mentorship.rb
@@ -46,9 +46,14 @@ private
 
   def get_possible_mentors
     if mentee.stage_of_career == 5
-      User.where(mentor: true, waitlist: false, stage_of_career: 5).where( "mentor_times > ?", 0).where(mentor_industry: mentee.primary_industry).where("id != ?", mentee.id)
+      User.where(mentor: true, waitlist: false, stage_of_career: 5)
+          .where( "mentor_times > ?", 0)
+          .where(mentor_industry: mentee.primary_industry)
+          .where("id != ?", mentee.id)
     else
-      User.where(mentor: true, waitlist: false).where("stage_of_career > ? AND mentor_times > ?", mentee.stage_of_career, 0).where(mentor_industry: mentee.primary_industry)
+      User.where(mentor: true, waitlist: false)
+          .where("stage_of_career > ? AND mentor_times > ?", mentee.stage_of_career, 0)
+          .where(mentor_industry: mentee.primary_industry)
     end
   end
 


### PR DESCRIPTION
## Migrations
NO

## Description
In order to create code that is easy to read, I made chained .where clauses more readable in get_possible_mentors method

## Github Issue
Fixes # 30

## Definition of Done

- [x] This PR has appropriate test coverage.
- [ n/a] Documentation has been updated. *(if needed)*
