### PR TITLE
Update copyright year (to a dynamic value) on welcome page

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -508,7 +508,7 @@
         <a href="info@womenrising.co" id='emailLink'>info@womenrising.co</a>
       </div>
       <div class="col-sm-4 col-md-6 copyright">
-        &copy Women Rising, 2015
+        &copy Women Rising, <%= Date.today.year %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Update copyright year on welcome page, from a static value of 2015, to a dynamic value of the current year

## Github Issue
Fixes #122

## Screenshots
![image](https://user-images.githubusercontent.com/1045616/34901201-732b32f2-f7c4-11e7-8734-84368ce3f073.png)

## Definition of Done
- [ N/A? ] This PR has appropriate test coverage.
