### PR TITLE
Update womenrising:peer_group_signup_reminder task and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ config/application.production.yml
 
 # copy one of the sample files instead
 config/database.yml
+
+# Ignore RubyMine files
+.idea/

--- a/lib/tasks/womenrising.rake
+++ b/lib/tasks/womenrising.rake
@@ -24,7 +24,7 @@ namespace :womenrising do
 
   desc 'Remind users to participate in peer matches'
   task :peer_group_signup_reminder => :environment do
-    if Date.today == (Date.today.end_of_month - 3.days)
+    if Date.current == (Date.current.end_of_month - 3.days)
       non_participating_users = User.where.not(is_participating_this_month: true)
       non_participating_users.each do |user|
         UserMailer.peer_group_signup_reminder(user).deliver_now

--- a/spec/lib/tasks/womenrising/peer_group_signup_reminder_rake_spec.rb
+++ b/spec/lib/tasks/womenrising/peer_group_signup_reminder_rake_spec.rb
@@ -13,7 +13,7 @@ describe "womenrising:peer_group_signup_reminder" do
   end
 
   it 'does not run on other days of the month' do
-    travel_to(DateTime.new(20018,1,26)) do
+    travel_to(DateTime.new(2018,1,26)) do
       subject.invoke
       expect(ActionMailer::Base.deliveries.map(&:to).flatten.count).to eq(0)
     end


### PR DESCRIPTION
## Description
This PR fixes time zone issues by using `Date.current` in lieu of `Date.today`. When running in a development environment in which the machine's time zone is set to local time, `Date.today` returns today's date in local time. The result is that setting the date using, for example, `travel_to(DateTime.new(2018,1,28))` will set the date to midnight UTC time, but the resulting `Date.today` will be the day before, assuming local time is a negative offset from UTC.

`Date.current`, by contrast, uses the time zone set by the server, avoiding the problem.

The PR also fixes a typo in the tests for this task.

## Github Issue
Fixes #(none)

*Notes regarding deploying the contained body of work.  These should note any
db migrations, new environment variables, etc.*

## Definition of Done

- [ ] This PR has appropriate test coverage.
- [ ] Documentation has been updated. *(if needed)*